### PR TITLE
chore: add origin header to forgot password email request

### DIFF
--- a/src/shared/actions/userService.ts
+++ b/src/shared/actions/userService.ts
@@ -15,7 +15,7 @@ import {
   type IUserDetailData,
 } from '@/shared/models/userInterfaces';
 import { errorHandling } from '@/shared/usecase/errorHandling';
-import { cookies } from 'next/headers';
+import { cookies, headers } from 'next/headers';
 import { getServerSession } from '../usecase/getServerSession';
 import type {
   ICreateProfilePayloadRoot,
@@ -58,9 +58,14 @@ export async function clearSessions() {
 export async function forgotPassword(
   payload: IForgotPasswordPayload
 ): Promise<IPostGeneralResponse<string>> {
+  const headerProto = headers().get('x-forwarded-proto');
+  const headerForwardedHost = headers().get('x-forwarded-host');
   const res = await fetch(baseURL + '/auth/forgot-password', {
     method: 'POST',
     body: JSON.stringify(payload),
+    headers: {
+      Origin: `${headerProto}://${headerForwardedHost}/`,
+    },
   });
 
   if (!res.ok) {


### PR DESCRIPTION
Adding `Origin` header to forgot password email requests' fetch call since it is previously detected to be undefined.

```typescript
  const headerProto = headers().get('x-forwarded-proto');
  const headerForwardedHost = headers().get('x-forwarded-host');
  const res = await fetch(baseURL + '/auth/forgot-password', {
    method: 'POST',
    body: JSON.stringify(payload),
    headers: {
      Origin: `${headerProto}://${headerForwardedHost}/`,
    },
  });
}
```