### PR TITLE
feat: integrating user statistics

### DIFF
--- a/src/app/dashboard/container/Section/MyDashboardSection.tsx
+++ b/src/app/dashboard/container/Section/MyDashboardSection.tsx
@@ -1,4 +1,4 @@
-"use client"
+'use client';
 
 import './style.scss';
 import { BudgetIcon } from '@/shared/container/Icon/BudgetIcon';
@@ -10,14 +10,28 @@ import { ToDoIcon } from '@/shared/container/Icon/ToDoIcon';
 import { VendorIcon } from '@/shared/container/Icon/VendorIcon';
 import DashboardCard from '../card/DashboardCard';
 import React from 'react';
+import { useGetStatistics } from '../../usecase/useGetStatistics';
+import CustomErrorBoundary from '@/shared/container/ErrorBoundary/ErrorBoundary';
+import formatToRupiah from '@/shared/usecase/formatToRupiah';
 
 const MyDashboardSection = () => {
+  const { data: result, isLoading, isError, error } = useGetStatistics();
+
+  if (isLoading)
+    return (
+      <div className="flex w-full h-[28rem] animate-pulse bg-ny-gray-300 rounded-lg mt-4" />
+    );
+  if (isError) return <CustomErrorBoundary error={error} />;
+  if (!result) return;
+
+  const { budget, guests, inspirations, todo, vendors } = result.data;
+
   return (
     <section className="grid grid-cols-2 gap-3 pt-3">
       <div className="col-span-2">
-        <DashboardCard title="Progress" icon={<HeartIcon />}>
+        <DashboardCard title="To-Do Progress" icon={<HeartIcon />}>
           <Progress
-            percent={10}
+            percent={todo.progress}
             strokeColor={'#ffffff'}
             trailColor={'#FC9CA9'}
           />
@@ -26,32 +40,43 @@ const MyDashboardSection = () => {
       <DashboardCard
         title="Inspirations"
         icon={<InspirationIcon />}
-        stats="300 Photos"
+        stats={`${inspirations} photos`}
       />
-      <DashboardCard title="Vendors" icon={<VendorIcon />} stats="20 Vendors" />
+      <DashboardCard
+        title="Vendors"
+        icon={<VendorIcon />}
+        stats={`${vendors} vendors`}
+      />
       <div className="row-span-2">
         <DashboardCard
           title="Budget"
           icon={<BudgetIcon />}
-          stats="RP 300.000.000"
-        >
+          stats={formatToRupiah(budget.total)}>
           <div className="flex items-center justify-center">
             <Progress
               type="circle"
-              percent={50}
+              percent={parseFloat(budget.progress.replace('%', ''))}
               strokeColor={'#ffffff'}
               trailColor={'#FC9CA9'}
-              format={(Percent) => (
+              format={(percent) => (
                 <span className="text-caption-1 font-semibold my-auto">
-                  {Percent}%
+                  {percent}%
                 </span>
               )}
             />
           </div>
         </DashboardCard>
       </div>
-      <DashboardCard title="Guests" icon={<GuestIcon />} stats="300 Invited" />
-      <DashboardCard title="To-Do List" icon={<ToDoIcon />} stats="10/20" />
+      <DashboardCard
+        title="Guests"
+        icon={<GuestIcon />}
+        stats={`${guests} invited`}
+      />
+      <DashboardCard
+        title="To-Do List"
+        icon={<ToDoIcon />}
+        stats={`${todo.done}/${todo.total}`}
+      />
     </section>
   );
 };

--- a/src/app/dashboard/usecase/useGetStatistics.ts
+++ b/src/app/dashboard/usecase/useGetStatistics.ts
@@ -1,0 +1,9 @@
+import { getUserStatistics } from '@/shared/actions/userService';
+import { useQuery } from 'react-query';
+
+export const useGetStatistics = () => {
+  return useQuery({
+    queryKey: ['get-user-statistics'],
+    queryFn: () => getUserStatistics(),
+  });
+};

--- a/src/app/profile/container/StatisticsItem.tsx
+++ b/src/app/profile/container/StatisticsItem.tsx
@@ -1,20 +1,18 @@
-import type { ReactNode } from 'react';
+import type { IUserStatistics } from '@/shared/models/userInterfaces';
+import formatToCapitalWord from '@/shared/usecase/formatToCapitalWord';
 
-type StatisticsItemProps<T extends ReactNode> = {
-  fetchFn: () => Promise<T>;
-  name: string;
-};
-
-export default async function StatisticsItem<T extends ReactNode>({
-  fetchFn,
-  name,
-}: StatisticsItemProps<T>) {
-  const statisticsCount = await fetchFn();
-
+export default function StatisticsItem({
+  statistic,
+}: {
+  statistic: {
+    name: keyof IUserStatistics;
+    value: number;
+  };
+}) {
   return (
     <div className="flex flex-col gap-1 items-center text-ny-primary-500">
-      <p className="text-3xl font-semibold">{statisticsCount}</p>
-      <p className="text-caption-1">{name}</p>
+      <p className="text-3xl font-semibold">{statistic.value}</p>
+      <p className="text-caption-1">{formatToCapitalWord(statistic.name)}</p>
     </div>
   );
 }

--- a/src/app/profile/container/UserStatistics.tsx
+++ b/src/app/profile/container/UserStatistics.tsx
@@ -1,21 +1,24 @@
-import useGetInspirationCount from '../usecase/useGetInspirationCount';
 import StatisticsItem from './StatisticsItem';
-import useGetReviewCount from '../usecase/useGetReviewCount';
-import useGetVendorCount from '../usecase/useGetVendorCount';
 import ColorfulBackgroundCard from '@/shared/container/ColorfulBackgroundCard/ColorfulBackgroundCard';
+import { getUserStatistics } from '@/shared/actions/userService';
 
-const statistics = [
-  { name: 'Reviews', fetchFn: useGetReviewCount },
-  { name: 'Inspiration', fetchFn: useGetInspirationCount },
-  { name: 'Inspiration', fetchFn: useGetVendorCount },
+const statisticsName = [
+  'reviews' as const,
+  'inspirations' as const,
+  'vendors' as const,
 ];
 
 export default async function UserStatistics() {
+  const statistics = await getUserStatistics();
+
   return (
     <ColorfulBackgroundCard className="flex items-center overflow-hidden gap-8 justify-center p-3 rounded-lg relative">
       <div className="flex items-center gap-8 z-[1]">
-        {statistics.map((statistic) => (
-          <StatisticsItem key={'statistic-' + statistic.name} {...statistic} />
+        {statisticsName.map((name) => (
+          <StatisticsItem
+            key={'statistic-' + name}
+            statistic={{ name, value: statistics.data[name] }}
+          />
         ))}
       </div>
     </ColorfulBackgroundCard>

--- a/src/app/profile/layout.tsx
+++ b/src/app/profile/layout.tsx
@@ -1,6 +1,7 @@
 import CustomErrorBoundary from '@/shared/container/ErrorBoundary/ErrorBoundary';
 import React, { Suspense } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
+import LoadingProfile from './loading';
 
 export default function ProfileRootLayout({
   children,
@@ -9,7 +10,7 @@ export default function ProfileRootLayout({
 }>) {
   return (
     <ErrorBoundary FallbackComponent={CustomErrorBoundary}>
-      <Suspense fallback={null}>{children}</Suspense>
+      <Suspense fallback={<LoadingProfile />}>{children}</Suspense>
     </ErrorBoundary>
   );
 }

--- a/src/app/profile/loading.tsx
+++ b/src/app/profile/loading.tsx
@@ -1,0 +1,45 @@
+import ColorfulBackgroundCard from '@/shared/container/ColorfulBackgroundCard/ColorfulBackgroundCard';
+import PageTitle from '@/shared/container/PageTitle/PageTitle';
+import React from 'react';
+import ProfileNavigationButton from './container/ProfileNavigationButton';
+import ProfileLogOutButton from './container/ProfileLogOutButton';
+
+const navigationMenu = [
+  { label: 'Wedding Settings', href: '/profile/wedding-settings' },
+  { label: 'My Order', href: '/order' },
+  { label: 'My Review', href: '/profile/review' },
+  { label: 'Contact & Information', href: '/profile/contact' },
+];
+
+const LoadingProfile = () => {
+  return (
+    <main className="flex flex-col size-full min-h-screen gap-5">
+      <PageTitle title="My Profile" />
+
+      <div className="flex flex-col gap-5 px-4 flex-grow pb-5">
+        <div className="flex flex-col gap-5">
+          <div className="w-full h-16 animate-pulse bg-ny-gray-300 rounded-lg" />
+          <ColorfulBackgroundCard className="flex items-center overflow-hidden gap-8 justify-center p-3 rounded-lg relative h-20" />
+        </div>
+
+        <div className="flex flex-col gap-3 w-full flex-grow">
+          {navigationMenu.map((menu) => (
+            <ProfileNavigationButton disabled key={menu.href} {...menu} />
+          ))}
+        </div>
+
+        <div className="flex flex-col gap-3 w-full">
+          <ProfileNavigationButton
+            disabled
+            href="/profile/change-password"
+            label="Change Password"
+          />
+
+          <ProfileLogOutButton disabled />
+        </div>
+      </div>
+    </main>
+  );
+};
+
+export default LoadingProfile;

--- a/src/app/profile/usecase/useGetInspirationCount.ts
+++ b/src/app/profile/usecase/useGetInspirationCount.ts
@@ -1,3 +1,0 @@
-export default async function useGetInspirationCount() {
-  return Promise.resolve(32);
-}

--- a/src/app/profile/usecase/useGetReviewCount.ts
+++ b/src/app/profile/usecase/useGetReviewCount.ts
@@ -1,3 +1,0 @@
-export default async function useGetReviewCount() {
-  return Promise.resolve(15);
-}

--- a/src/app/profile/usecase/useGetVendorCount.ts
+++ b/src/app/profile/usecase/useGetVendorCount.ts
@@ -1,3 +1,0 @@
-export default async function useGetVendorCount() {
-  return Promise.resolve(12);
-}

--- a/src/shared/models/userInterfaces.ts
+++ b/src/shared/models/userInterfaces.ts
@@ -28,7 +28,7 @@ export interface IUserVendorDetail {
   avg_rating: number;
   vendor_detail: IVendorDetail;
   is_wishlist: boolean;
-  review: IReview
+  review: IReview;
 }
 
 export interface IUserVendorAdditionalDetail {
@@ -102,4 +102,32 @@ export interface IVendorWishlist {
 
 export interface IAllVendorWishlistResponse extends IGeneralWishlistResponse {
   vendors: IVendorWishlist[];
+}
+
+export interface IUserStatisticsResponseRoot {
+  total_budget: number;
+  progress_budget: string;
+  total_inspiration: number;
+  total_guest: number;
+  total_vendor: number;
+  total_todo_done: number;
+  total_todo: number;
+  progress_todo: string;
+  total_review: number;
+}
+
+export interface IUserStatistics {
+  inspirations: number;
+  guests: number;
+  vendors: number;
+  reviews: number;
+  todo: {
+    total: number;
+    done: number;
+    progress: number;
+  };
+  budget: {
+    total: number;
+    progress: string;
+  };
 }


### PR DESCRIPTION
Currently the backend responded with error 500, so I tested it by mocking the response as shown in the endpoint's postman example. It is expected to work fine after backend response is fixed.

<img width="255" alt="image" src="https://github.com/user-attachments/assets/41aacbb9-0706-45a0-b84e-5cc75b596d8a">

# UI Preview
### Dashboard
![image](https://github.com/user-attachments/assets/7b5859a0-4f85-4bb5-963c-244835395966)

### Profile page
![image](https://github.com/user-attachments/assets/0b984230-6979-4f96-8ad6-a961e93e2c3b)
