### PR TITLE
feat: integrating notifications

### DIFF
--- a/src/app/budget/container/Loading/SectionUnpaidBudgetsLoading.tsx
+++ b/src/app/budget/container/Loading/SectionUnpaidBudgetsLoading.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export const SectionUnpaidBudgetsLoading = () => {
+  return (
+    <div className="h-full pb-4 grid grid-flow-col overflow-x-auto no-scrollbar w-full gap-3 text-black">
+      {Array.from(Array(10).keys()).map((key) => (
+        <div
+          key={key}
+          className="w-44 h-16 bg-white animate-pulse rounded-lg shadow"
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/app/budget/container/Section/SectionHero.tsx
+++ b/src/app/budget/container/Section/SectionHero.tsx
@@ -3,7 +3,8 @@ import HeaderDefault from '@/shared/container/Header/HeaderDefault';
 import formatToRupiah from '@/shared/usecase/formatToRupiah';
 import { Progress } from 'antd';
 import { Suspense } from 'react';
-import { BudgetGroup } from '../Group/BudgetGroup';
+import { SectionUnpaidBudgets } from './SectionUnpaidBudgets';
+import { SectionUnpaidBudgetsLoading } from '../Loading/SectionUnpaidBudgetsLoading';
 
 async function SectionHero() {
   const { data } = await getUserBudgets();
@@ -45,15 +46,9 @@ async function SectionHero() {
         />
       </div>
 
-      <div className="h-full pb-4 grid grid-flow-col overflow-x-auto no-scrollbar w-full gap-3 text-black">
-        {data.budgets.map((budget) => (
-          <BudgetGroup
-            key={budget.id}
-            name={budget.name}
-            nominal={budget.nominal}
-          />
-        ))}
-      </div>
+      <Suspense fallback={<SectionUnpaidBudgetsLoading />}>
+        <SectionUnpaidBudgets />
+      </Suspense>
       <div className="bg-white h-[21%] z-0 left-0 absolute bottom-0 w-full" />
     </section>
   );

--- a/src/app/budget/container/Section/SectionUnpaidBudgets.tsx
+++ b/src/app/budget/container/Section/SectionUnpaidBudgets.tsx
@@ -1,0 +1,18 @@
+import { getUserBudgets } from '@/shared/actions/budgetService';
+import React from 'react';
+import { BudgetGroup } from '../Group/BudgetGroup';
+
+export const SectionUnpaidBudgets = async () => {
+  const { data } = await getUserBudgets({ status: 'need-to-pay' });
+  return (
+    <div className="h-full pb-4 grid grid-flow-col overflow-x-auto no-scrollbar w-full gap-3 text-black">
+      {data.budgets.map((budget) => (
+        <BudgetGroup
+          key={budget.id}
+          name={budget.name}
+          nominal={budget.nominal}
+        />
+      ))}
+    </div>
+  );
+};

--- a/src/app/cart/usecase/useMutateOrder.tsx
+++ b/src/app/cart/usecase/useMutateOrder.tsx
@@ -2,15 +2,19 @@ import { createOrder } from '@/shared/actions/productService';
 import { message } from 'antd';
 import { useMutation } from 'react-query';
 import { useRouter } from 'next/navigation';
+import { useNotifyOrder } from './useNotifyOrder';
+import type { IPostGeneralSuccessResponse } from '@/shared/models/generalInterfaces';
 
 const useMutateOrder = () => {
   const router = useRouter();
+  const { mutate: notify } = useNotifyOrder();
 
   const { mutate: handleCreateOrder, isLoading: isCreatingOrder } = useMutation(
     {
       mutationFn: (productsid: number[]) => createOrder(productsid),
       onSuccess: (data) => {
         if (data.success) {
+          notify((data.data as IPostGeneralSuccessResponse<number[]>).data);
           message.success('Order created successfully!');
           router.push('/order?type=ordered');
         } else {

--- a/src/app/cart/usecase/useNotifyOrder.ts
+++ b/src/app/cart/usecase/useNotifyOrder.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import { notifyNewOrder } from '@/shared/actions/productService';
+import type { IOrder } from '@/shared/models/orderInterfaces';
+import { useMutation } from 'react-query';
+
+export const useNotifyOrder = () => {
+  return useMutation({
+    mutationKey: ['notify-order'],
+    mutationFn: (orderId: IOrder['id'][]) => notifyNewOrder(orderId),
+  });
+};

--- a/src/app/chat/[vendorId]/usecase/useNotifyChat.ts
+++ b/src/app/chat/[vendorId]/usecase/useNotifyChat.ts
@@ -1,0 +1,20 @@
+'use client';
+
+import { createNotification } from '@/shared/actions/notificationService';
+import type { IVendor } from '@/shared/models/productInterfaces';
+import { getClientSession } from '@/shared/usecase/getClientSession';
+import { useMutation } from 'react-query';
+
+export const useNotifyChat = (vendorId: IVendor['id']) => {
+  const session = getClientSession();
+  return useMutation({
+    mutationKey: ['notify-chat', { vendorId }],
+    mutationFn: () =>
+      createNotification({
+        title: 'New message arrived!',
+        description: `${session.user_detail.name} sent you a message!`,
+        user_id: vendorId,
+        status: 'unread',
+      }),
+  });
+};

--- a/src/app/chat/[vendorId]/usecase/useSendChatToVendor.ts
+++ b/src/app/chat/[vendorId]/usecase/useSendChatToVendor.ts
@@ -14,6 +14,7 @@ import { getClientSession } from '@/shared/usecase/getClientSession';
 import { usePathname, useRouter } from 'next/navigation';
 import dayjs from 'dayjs';
 import { TQuotedCardProduct } from '../container/QuotedProductCard/QuotedCard';
+import { useNotifyChat } from './useNotifyChat';
 
 const useSendChatToVendor = (
   vendor: IAllUserResponse,
@@ -23,6 +24,7 @@ const useSendChatToVendor = (
   const router = useRouter();
   const pathname = usePathname();
   const combinedId: string = user.user_id + '.' + vendor.id;
+  const { mutate: notify } = useNotifyChat(vendor.id);
 
   const onSendChat = async (text: string) => {
     // check if this is new chat or not,
@@ -94,6 +96,7 @@ const useSendChatToVendor = (
       },
     });
 
+    notify();
     if (quotedProduct) {
       clearQuoteProduct();
     }

--- a/src/app/notification/container/MarkAllAsRead.tsx
+++ b/src/app/notification/container/MarkAllAsRead.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Button } from 'antd';
+import React from 'react';
+import { useReadAllNotifications } from '../usecase/useReadAllNotifications';
+
+export const MarkAllAsRead = () => {
+  const { mutate: readAll } = useReadAllNotifications();
+  return (
+    <Button
+      onClick={() => readAll()}
+      type="link"
+      className="text-caption-2 w-full max-w-max text-right font-semibold text-ny-primary-500">
+      MARK ALL AS READ
+    </Button>
+  );
+};

--- a/src/app/notification/container/NotificationCard.tsx
+++ b/src/app/notification/container/NotificationCard.tsx
@@ -1,0 +1,34 @@
+import type { TNotification } from '@/shared/models/notificationInterfaces';
+import dayjs from 'dayjs';
+import React from 'react';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+
+dayjs.extend(customParseFormat);
+dayjs.extend(relativeTime);
+
+export const NotificationCard = ({
+  notification,
+}: {
+  notification: TNotification;
+}) => {
+  return (
+    <div className="grid grid-rows-[auto_1fr] gap-y-3 p-4 rounded-lg border">
+      <div className="flex items-center justify-between flex-wrap-reverse gap-y-1">
+        <span
+          className={`text-body-2 font-semibold ${
+            notification.status === 'unread' && 'text-ny-primary-500'
+          }`}>
+          {notification.title}
+        </span>
+        <span className="text-caption-2 text-ny-gray-500">
+          {dayjs(
+            notification.notification_time,
+            'DD-MM-YYYY HH:mm:ss'
+          ).fromNow()}
+        </span>
+      </div>
+      <p className="text-caption-1">{notification.description}</p>
+    </div>
+  );
+};

--- a/src/app/notification/container/NotificationCard.tsx
+++ b/src/app/notification/container/NotificationCard.tsx
@@ -3,9 +3,13 @@ import dayjs from 'dayjs';
 import React from 'react';
 import relativeTime from 'dayjs/plugin/relativeTime';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
 
 dayjs.extend(customParseFormat);
 dayjs.extend(relativeTime);
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export const NotificationCard = ({
   notification,
@@ -22,10 +26,10 @@ export const NotificationCard = ({
           {notification.title}
         </span>
         <span className="text-caption-2 text-ny-gray-500">
-          {dayjs(
-            notification.notification_time,
-            'DD-MM-YYYY HH:mm:ss'
-          ).fromNow()}
+          {dayjs(notification.notification_time, 'DD-MM-YYYY HH:mm:ss')
+            .tz('Asia/Jakarta')
+            .local()
+            .fromNow()}
         </span>
       </div>
       <p className="text-caption-1">{notification.description}</p>

--- a/src/app/notification/container/ReadNotifications.tsx
+++ b/src/app/notification/container/ReadNotifications.tsx
@@ -1,0 +1,20 @@
+import { getNotifications } from '@/shared/actions/notificationService';
+import React from 'react';
+import { NotificationCard } from './NotificationCard';
+import { Divider } from 'antd';
+
+export const ReadNotifications = async ({
+  showDivider,
+}: {
+  showDivider: boolean;
+}) => {
+  const notifications = await getNotifications('read');
+  return (
+    <>
+      {showDivider && notifications.data.length > 0 && <Divider />}
+      {notifications.data.map((notification) => (
+        <NotificationCard key={notification.id} notification={notification} />
+      ))}
+    </>
+  );
+};

--- a/src/app/notification/layout.tsx
+++ b/src/app/notification/layout.tsx
@@ -1,0 +1,26 @@
+import CustomErrorBoundary from '@/shared/container/ErrorBoundary/ErrorBoundary';
+import PageTitle from '@/shared/container/PageTitle/PageTitle';
+import React, { Suspense } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
+import NotificationLoading from './loading';
+import { MarkAllAsRead } from './container/MarkAllAsRead';
+
+const NotificationRootLayout = ({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) => {
+  return (
+    <ErrorBoundary FallbackComponent={CustomErrorBoundary}>
+      <main className="flex flex-col">
+        <div className="flex items-center justify-between">
+          <PageTitle title="Notification" />
+          <MarkAllAsRead />
+        </div>
+        <Suspense fallback={<NotificationLoading />}>{children}</Suspense>
+      </main>
+    </ErrorBoundary>
+  );
+};
+
+export default NotificationRootLayout;

--- a/src/app/notification/loading.tsx
+++ b/src/app/notification/loading.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+const NotificationLoading = () => {
+  return (
+    <div className="p-4 flex flex-col gap-3">
+      <div className="bg-ny-gray-100 rounded-lg h-24 animate-pulse" />
+      <div className="bg-ny-gray-100 rounded-lg h-24 animate-pulse" />
+      <div className="bg-ny-gray-100 rounded-lg h-24 animate-pulse" />
+      <div className="bg-ny-gray-100 rounded-lg h-24 animate-pulse" />
+    </div>
+  );
+};
+
+export default NotificationLoading;

--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -1,0 +1,35 @@
+import { getNotifications } from '@/shared/actions/notificationService';
+import React, { Suspense } from 'react';
+import { NotificationCard } from './container/NotificationCard';
+import { ReadNotifications } from './container/ReadNotifications';
+import NotificationLoading from './loading';
+
+const NotificationPage = async () => {
+  const notifications = await getNotifications('unread');
+  const hasNewNotifications = notifications.data.length > 0;
+
+  return (
+    <div className="p-4 flex flex-col gap-3">
+      {hasNewNotifications ? (
+        <div className="flex items-center gap-8 mb-3">
+          <hr className="h-2 w-full" />
+          <p className="w-max text-caption-1 font-semibold whitespace-nowrap text-center">
+            New notifications
+          </p>
+          <hr className="h-2 w-full" />
+        </div>
+      ) : null}
+
+      {notifications.data.map((notification) => (
+        <NotificationCard key={notification.id} notification={notification} />
+      ))}
+
+      {/* Getting read notifications is expected to take longer than getting the unread ones, components is separated to reduce loading time */}
+      <Suspense fallback={<NotificationLoading />}>
+        <ReadNotifications showDivider={hasNewNotifications} />
+      </Suspense>
+    </div>
+  );
+};
+
+export default NotificationPage;

--- a/src/app/notification/usecase/useReadAllNotifications.ts
+++ b/src/app/notification/usecase/useReadAllNotifications.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { readAllNotifications } from '@/shared/actions/notificationService';
+import { useMutation, useQueryClient } from 'react-query';
+
+export const useReadAllNotifications = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationKey: ['read-all-notifications'],
+    mutationFn: () => readAllNotifications(),
+    onSuccess: () => {
+      queryClient.refetchQueries(['use-get-notifications-count']);
+    },
+  });
+};

--- a/src/app/order/(default)/usecase/useNotifyPayment.ts
+++ b/src/app/order/(default)/usecase/useNotifyPayment.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import { notifyUpdatePayment } from '@/shared/actions/orderService';
+import type { IOrder } from '@/shared/models/orderInterfaces';
+import { useMutation } from 'react-query';
+
+export const useNotifyPayment = (orderId: IOrder['id']) => {
+  return useMutation({
+    mutationKey: ['notify-payment', { orderId }],
+    mutationFn: () => notifyUpdatePayment(orderId),
+  });
+};

--- a/src/app/order/(default)/usecase/useUploadReceipt.ts
+++ b/src/app/order/(default)/usecase/useUploadReceipt.ts
@@ -8,6 +8,7 @@ import { message } from 'antd';
 import { useMutation, useQueryClient } from 'react-query';
 import transformOrderPaymentInput from '../repository/transformOrderPaymentInput';
 import { useRouter } from 'next/navigation';
+import { useNotifyPayment } from './useNotifyPayment';
 
 type TUseUploadReceiptParams = {
   id: string;
@@ -15,6 +16,7 @@ type TUseUploadReceiptParams = {
 };
 
 export default function useUploadReceipt(params: TUseUploadReceiptParams) {
+  const { mutate: notify } = useNotifyPayment(parseInt(params.id));
   const queryClient = useQueryClient();
   const router = useRouter();
 
@@ -32,6 +34,7 @@ export default function useUploadReceipt(params: TUseUploadReceiptParams) {
       message.loading('Uploading receipt...');
     },
     onSuccess: () => {
+      notify();
       queryClient.refetchQueries(['waiting for payment']);
       message.success('Successfully uploaded payment receipt!');
       params.closeModal();

--- a/src/app/order/(review)/review/[orderId]/container/AddReviewContainer.tsx
+++ b/src/app/order/(review)/review/[orderId]/container/AddReviewContainer.tsx
@@ -25,7 +25,9 @@ export default function AddReviewContainer({
   if (isLoading && failureCount < 2) return <AddReviewFormLoading />;
 
   const initialValues =
-    data && data.data ? formatQueryData(data.data[0]) : undefined;
+    data && data.data && data.data.length > 0
+      ? formatQueryData(data.data[0])
+      : undefined;
   const shouldEdit = initialValues !== undefined;
   const isMutating = isAddingReview || isEditingReview;
 

--- a/src/app/order/(review)/review/[orderId]/usecase/useNotifyReview.ts
+++ b/src/app/order/(review)/review/[orderId]/usecase/useNotifyReview.ts
@@ -1,0 +1,12 @@
+'use client';
+
+import { notifyAddReview } from '@/shared/actions/productService';
+import type { IAllProductsResponse } from '@/shared/models/productInterfaces';
+import { useMutation } from 'react-query';
+
+export const useNotifyReview = (productId: IAllProductsResponse['id']) => {
+  return useMutation({
+    mutationKey: ['notify-add-review', { productId }],
+    mutationFn: () => notifyAddReview(productId),
+  });
+};

--- a/src/app/order/(review)/review/[orderId]/usecase/useProductReview.ts
+++ b/src/app/order/(review)/review/[orderId]/usecase/useProductReview.ts
@@ -13,8 +13,10 @@ import {
 } from '@/shared/models/productInterfaces';
 import { message } from 'antd';
 import { useMutation, useQuery } from 'react-query';
+import { useNotifyReview } from './useNotifyReview';
 
 export default function useProductReview(productId: number) {
+  const { mutate: notify } = useNotifyReview(productId);
   const addProductReview = (value: IAddProductReviewPayload) =>
     addReview(productId, value);
 
@@ -39,7 +41,8 @@ export default function useProductReview(productId: number) {
   >({
     mutationKey: ['add-review', { productId }],
     mutationFn: addProductReview,
-    onSuccess: () => {
+    onSuccess: async () => {
+      notify();
       message.success('Successfully added a review!');
     },
     onError: (error) => {
@@ -55,6 +58,7 @@ export default function useProductReview(productId: number) {
     mutationKey: ['edit-review', { productId }],
     mutationFn: editProductReview,
     onSuccess: () => {
+      notify();
       message.success('Successfully edited a review!');
     },
     onError: (error) => {

--- a/src/shared/actions/notificationService.ts
+++ b/src/shared/actions/notificationService.ts
@@ -5,6 +5,7 @@ import type {
   IPostGeneralSuccessResponse,
 } from '../models/generalInterfaces';
 import type {
+  TAdminNotificationPayload,
   TNotification,
   TNotificationPayload,
   TNotificationStatus,
@@ -13,18 +14,15 @@ import type {
 import { errorHandling } from '../usecase/errorHandling';
 import { getServerSession } from '../usecase/getServerSession';
 import convertObjectToQueryParams from '../usecase/convertObjectToQueryParams';
+import { revalidatePath } from 'next/cache';
 
 const endpoint = process.env.NEXT_PUBLIC_API as string;
 
-export const getNotifications = async ({
-  status = 'unread',
-}: {
-  status?: TNotificationStatus;
-}) => {
+export const getNotifications = async (status?: TNotificationStatus) => {
   const { user_id, token } = await getServerSession();
   const queries = convertObjectToQueryParams({
     user_id,
-    status,
+    status: status ?? 'unread',
   });
 
   const response = await fetch(endpoint + `/notifications?${queries}`, {
@@ -93,6 +91,30 @@ export const createNotification = async (payload: TNotificationPayload) => {
   return { success: true, data };
 };
 
+export const createAdminNotification = async (
+  payload: TAdminNotificationPayload
+) => {
+  const { token } = await getServerSession();
+  const response = await fetch(endpoint + '/admin-notifications', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await errorHandling(response);
+    throw new Error(error.data);
+  }
+
+  const { data } = (await response.json()) as IPostGeneralSuccessResponse<
+    TNotification['id']
+  >;
+
+  return { success: true, data };
+};
+
 export const updateNotification = async (
   payload: TUpdateNotificationPayload
 ) => {
@@ -119,7 +141,7 @@ export const updateNotification = async (
 
 export const readAllNotifications = async () => {
   const { token } = await getServerSession();
-  const response = await fetch(endpoint + '/notifications', {
+  const response = await fetch(endpoint + '/notifications/mark-all-as-read', {
     method: 'PATCH',
     headers: {
       Authorization: `Bearer ${token}`,
@@ -131,6 +153,7 @@ export const readAllNotifications = async () => {
     throw new Error(error.data);
   }
 
+  revalidatePath('/notification');
   const { data } =
     (await response.json()) as IPostGeneralSuccessResponse<'success'>;
 

--- a/src/shared/actions/notificationService.ts
+++ b/src/shared/actions/notificationService.ts
@@ -1,0 +1,138 @@
+'use server';
+
+import type {
+  IFetchGeneralResponse,
+  IPostGeneralSuccessResponse,
+} from '../models/generalInterfaces';
+import type {
+  TNotification,
+  TNotificationPayload,
+  TNotificationStatus,
+  TUpdateNotificationPayload,
+} from '../models/notificationInterfaces';
+import { errorHandling } from '../usecase/errorHandling';
+import { getServerSession } from '../usecase/getServerSession';
+import convertObjectToQueryParams from '../usecase/convertObjectToQueryParams';
+
+const endpoint = process.env.NEXT_PUBLIC_API as string;
+
+export const getNotifications = async ({
+  status = 'unread',
+}: {
+  status?: TNotificationStatus;
+}) => {
+  const { user_id, token } = await getServerSession();
+  const queries = convertObjectToQueryParams({
+    user_id,
+    status,
+  });
+
+  const response = await fetch(endpoint + `/notifications?${queries}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await errorHandling(response);
+    throw new Error(error.data);
+  }
+
+  const { data } = (await response.json()) as IFetchGeneralResponse<
+    TNotification[]
+  >;
+
+  return { success: true, data };
+};
+
+export const getNotificationById = async ({
+  id,
+}: {
+  id: TNotification['id'];
+}) => {
+  const { token } = await getServerSession();
+
+  const response = await fetch(endpoint + `/notifications/${id}`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await errorHandling(response);
+    throw new Error(error.data);
+  }
+
+  const { data } =
+    (await response.json()) as IFetchGeneralResponse<TNotification>;
+
+  return { success: true, data };
+};
+
+export const createNotification = async (payload: TNotificationPayload) => {
+  const { token } = await getServerSession();
+  const response = await fetch(endpoint + '/notifications', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await errorHandling(response);
+    throw new Error(error.data);
+  }
+
+  const { data } = (await response.json()) as IPostGeneralSuccessResponse<
+    TNotification['id']
+  >;
+
+  return { success: true, data };
+};
+
+export const updateNotification = async (
+  payload: TUpdateNotificationPayload
+) => {
+  const { token } = await getServerSession();
+  const response = await fetch(endpoint + '/notifications', {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await errorHandling(response);
+    throw new Error(error.data);
+  }
+
+  const { data } = (await response.json()) as IPostGeneralSuccessResponse<
+    TNotification['id']
+  >;
+
+  return { success: true, data };
+};
+
+export const readAllNotifications = async () => {
+  const { token } = await getServerSession();
+  const response = await fetch(endpoint + '/notifications', {
+    method: 'PATCH',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  if (!response.ok) {
+    const error = await errorHandling(response);
+    throw new Error(error.data);
+  }
+
+  const { data } =
+    (await response.json()) as IPostGeneralSuccessResponse<'success'>;
+
+  return { success: true, data };
+};

--- a/src/shared/container/Header/HeaderDefault.tsx
+++ b/src/shared/container/Header/HeaderDefault.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { CartIcon } from '../Icon/CartIcon';
 import { NotificationIcon } from '../Icon/NotificationIcon';
+import { NotificationBadge } from '../NotificationBadge/NotificationBadge';
 
 async function HeaderDefault() {
   const sessionData = await getServerSession();
@@ -24,8 +25,10 @@ async function HeaderDefault() {
         </Link>
         <Link
           href={'/notification'}
-          className="rounded-md p-1 hover:bg-ny-primary-200 hover:bg-opacity-35 transition-all duration-150">
-          <NotificationIcon />
+          className="rounded-md p-2 pb-[2px] hover:bg-ny-primary-200 hover:bg-opacity-35 transition-all duration-150">
+          <NotificationBadge>
+            <NotificationIcon color="white" />
+          </NotificationBadge>
         </Link>
         <Link href={'/profile'} className="p-1">
           <div className="w-6 h-6 bg-ny-gray-100 rounded-lg border border-white relative overflow-hidden">

--- a/src/shared/container/Header/HeaderDesktop.tsx
+++ b/src/shared/container/Header/HeaderDesktop.tsx
@@ -7,6 +7,7 @@ import { usePathname } from 'next/navigation';
 import { CartIcon } from '../Icon/CartIcon';
 import { NotificationIcon } from '../Icon/NotificationIcon';
 import HeaderDesktopNavItem from './HeaderDesktopNavItem';
+import { NotificationBadge } from '../NotificationBadge/NotificationBadge';
 
 function HeaderDesktop() {
   const sessionData = getClientSession();
@@ -66,8 +67,10 @@ function HeaderDesktop() {
         </Link>
         <Link
           href={'/notification'}
-          className="rounded-md p-2 hover:bg-ny-primary-200 hover:bg-opacity-35 transition-all duration-150">
-          <NotificationIcon />
+          className="rounded-md p-2 pb-[2px] hover:bg-ny-primary-200 hover:bg-opacity-35 transition-all duration-150">
+          <NotificationBadge>
+            <NotificationIcon color="white" />
+          </NotificationBadge>
         </Link>
         <Link href={'/profile'} className="p-1">
           <div className="w-6 h-6 bg-ny-gray-100 rounded-lg border border-white relative overflow-hidden">

--- a/src/shared/container/NotificationBadge/NotificationBadge.tsx
+++ b/src/shared/container/NotificationBadge/NotificationBadge.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useGetNotificationsCount } from '@/shared/usecase/useGetNotificationsCount';
+import useMounted from '@/shared/usecase/useMounted';
+import { Badge } from 'antd';
+import React from 'react';
+
+export const NotificationBadge = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const mounted = useMounted();
+  const notificationCount = useGetNotificationsCount();
+  if (!mounted) return <Badge count={0}>{children}</Badge>;
+
+  return <Badge count={notificationCount}>{children}</Badge>;
+};

--- a/src/shared/models/notificationInterfaces.ts
+++ b/src/shared/models/notificationInterfaces.ts
@@ -1,0 +1,12 @@
+export type TNotification = {
+  id: number;
+  title: string;
+  description: string;
+  user_id: string;
+  notification_time: string;
+  status: TNotificationStatus;
+};
+
+export type TNotificationStatus = 'read' | 'unread';
+export type TNotificationPayload = Omit<TNotification, 'id'>;
+export type TUpdateNotificationPayload = Partial<TNotificationPayload>;

--- a/src/shared/models/notificationInterfaces.ts
+++ b/src/shared/models/notificationInterfaces.ts
@@ -8,5 +8,9 @@ export type TNotification = {
 };
 
 export type TNotificationStatus = 'read' | 'unread';
-export type TNotificationPayload = Omit<TNotification, 'id'>;
+export type TNotificationPayload = Omit<
+  TNotification,
+  'id' | 'notification_time'
+>;
+export type TAdminNotificationPayload = Omit<TNotificationPayload, 'user_id'>;
 export type TUpdateNotificationPayload = Partial<TNotificationPayload>;

--- a/src/shared/usecase/useGetNotificationsCount.ts
+++ b/src/shared/usecase/useGetNotificationsCount.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useQuery } from 'react-query';
+import { getNotifications } from '../actions/notificationService';
+
+export const useGetNotificationsCount = () => {
+  const { data, isError, isLoading } = useQuery({
+    queryKey: ['use-get-notifications-count'],
+    queryFn: () => getNotifications('unread'),
+    refetchInterval: 1000 * 60 * 5, // 5 minutes,
+  });
+
+  if (!data || !data.data || isError || isLoading) return 0;
+  return data.data.length;
+};


### PR DESCRIPTION
# Notes
I only send notifications when the main action is already finished, also I didn't throw any error when the notification action failed, this way the user can continue like usual without being affected by notifications error.

I also assumed the notification time returned from backend is using the UTC+7 timezone (like they said in group chat).

# Checkboxes
- [x] Notify vendor and admin when transaction has been created
- [x] Notify vendor and admin when transaction status changed (only possible action is when uploading payment proof)
- [x] Notify vendor when user submits a review
- [x] Notify vendor when there is a chat
- [x] Budget hero section only shows `need-to-pay` status

# UI
### Notification Badges
<img width="163" alt="image" src="https://github.com/user-attachments/assets/0b488e90-5e39-4d5a-b869-061c90265156">

### Notifications (with unreads)
<img width="480" alt="image" src="https://github.com/user-attachments/assets/e278744b-c4f2-4d60-9430-ec572bdae2f8">

### Notifications (without unreads)
<img width="480" alt="image" src="https://github.com/user-attachments/assets/990f4e63-f8ab-472a-a589-336cb29116d2">
