### PR TITLE
feat: search chat and small UI changes

### DIFF
--- a/src/app/budget/container/BudgetContainer.tsx
+++ b/src/app/budget/container/BudgetContainer.tsx
@@ -10,7 +10,7 @@ import { SectionBudgetListLoading } from './Loading/SectionBudgetListLoading';
 
 function BudgetContainer() {
   return (
-    <main className="flex flex-col gap-5 pb-24 max-w-screen-md mx-auto md:mt-5">
+    <main className="flex flex-col gap-5 pb-24 md:mt-5">
       <Suspense fallback={<SectionHeroLoading />}>
         <SectionHero />
       </Suspense>

--- a/src/app/budget/container/Section/SectionBudgetAllocation.tsx
+++ b/src/app/budget/container/Section/SectionBudgetAllocation.tsx
@@ -19,7 +19,7 @@ function SectionBudgetAllocation() {
   return (
     <TitledSection title="Budget Allocation" navigateTo="/budget/list">
       <div className="mx-4 flex items-center p-5 gap-4 sm:gap-8 rounded-lg shadow">
-        <div className="basis-1/2 sm:basis-1/3 w-full shrink-0 flex">
+        <div className="basis-1/2 sm:basis-1/3 w-full shrink-0 flex justify-center">
           <Doughnut className="w-full shrink-0" data={chartData} />
         </div>
         <div className="flex flex-col gap-4 w-full">

--- a/src/app/budget/container/Section/SectionHero.tsx
+++ b/src/app/budget/container/Section/SectionHero.tsx
@@ -10,10 +10,10 @@ async function SectionHero() {
   const { data } = await getUserBudgets();
 
   return (
-    <section className="text-white relative h-full -mb-[4.25rem] bg-gradient-to-r from-ny-primary-500 via-ny-primary-400 to-ny-primary-300 py-5 px-4 flex flex-col gap-6">
+    <section className="text-white relative h-full -mb-[4.25rem] bg-gradient-to-r from-ny-primary-500 via-ny-primary-400 to-ny-primary-300 py-5 px-4 flex flex-col gap-6 md:rounded-lg">
       <Suspense
         fallback={
-          <div className="w-full h-10 rounded-md animate-pulse bg-ny-gray-200"></div>
+          <div className="w-full h-10 rounded-md animate-pulse bg-ny-gray-200" />
         }>
         <HeaderDefault />
       </Suspense>
@@ -49,7 +49,10 @@ async function SectionHero() {
       <Suspense fallback={<SectionUnpaidBudgetsLoading />}>
         <SectionUnpaidBudgets />
       </Suspense>
-      <div className="bg-white h-[21%] z-0 left-0 absolute bottom-0 w-full" />
+
+      {data.budgets.length > 0 && data.total_budget !== data.total_spend ? (
+        <div className="bg-white h-[21%] z-0 left-0 absolute bottom-0 w-full" />
+      ) : null}
     </section>
   );
 }

--- a/src/app/budget/repositories/formatAllocationsData.ts
+++ b/src/app/budget/repositories/formatAllocationsData.ts
@@ -54,5 +54,15 @@ export const formatAllocationsData = (
     },
   ];
 
+  if (datasets[0].data.some((value) => isNaN(value))) {
+    return {
+      allocations,
+      chartData: {
+        labels: ['No Data'],
+        datasets: [{ data: [100], backgroundColor: '#F1F1F1' }],
+      },
+    };
+  }
+
   return { allocations, chartData: { labels, datasets } };
 };

--- a/src/app/chat/[vendorId]/container/SendMessageArea.tsx
+++ b/src/app/chat/[vendorId]/container/SendMessageArea.tsx
@@ -33,7 +33,7 @@ export default function SendMessageArea({
         form.resetFields();
       }}
       form={form}
-      className="w-full fixed bottom-0 max-w-screen-md">
+      className="w-full sticky bottom-0 bg-white max-w-screen-md">
       {quotedProductResult && (
         <div className="z-[100]">
           <QuotedCard

--- a/src/app/chat/[vendorId]/loading.tsx
+++ b/src/app/chat/[vendorId]/loading.tsx
@@ -4,7 +4,7 @@ import SkeletonInput from 'antd/es/skeleton/Input';
 
 export default function ChatRoomLoading() {
   return (
-    <>
+    <div className="grid grid-rows-[auto_1fr_auto] min-h-dvh">
       <PageTitle title="Loading..." />
 
       <section className="p-4 flex flex-col gap-4">
@@ -15,12 +15,12 @@ export default function ChatRoomLoading() {
           ))}
       </section>
 
-      <footer className="px-4 py-3 flex gap-2 items-center w-full border-t fixed bottom-0 max-w-screen-sm">
+      <footer className="px-4 py-3 flex gap-2 items-center w-full border-t fixed bottom-0 max-w-screen-md">
         <SkeletonInput active block />
         <Button disabled type="primary" htmlType="submit">
           Send
         </Button>
       </footer>
-    </>
+    </div>
   );
 }

--- a/src/app/chat/[vendorId]/page.tsx
+++ b/src/app/chat/[vendorId]/page.tsx
@@ -31,10 +31,8 @@ export default async function VendorRoomChatPage({
   }
 
   return (
-    <div className="relative">
-      <div className="fixed md:static z-[99] top-0 left-0 right-0 bg-white">
-        <PageTitle title={detailVendor.data.data.name} />
-      </div>
+    <div className="grid grid-rows-[auto_1fr_auto] min-h-dvh">
+      <PageTitle title={detailVendor.data.data.name} />
       <RoomChatContainer vendor={detailVendor.data.data} />
       <SendMessageArea
         vendor={detailVendor.data.data}

--- a/src/app/chat/container/ChatInfo.tsx
+++ b/src/app/chat/container/ChatInfo.tsx
@@ -16,7 +16,11 @@ export default function ChatInfo({ chat }: { chat: TListChats }) {
       className="flex gap-3 items-center w-full hover:cursor-pointer hover:bg-slate-100 p-[8px] hover:rounded-[5px]">
       <Avatar
         shape="circle"
-        src={chat.userInfo.displayPicture}
+        src={
+          chat.userInfo.displayPicture?.length > 0
+            ? chat.userInfo.displayPicture
+            : '/assets/default-profile-picture.jpg'
+        }
         className="size-[50px] shrink-0"
       />
       <div className="flex flex-col gap-1 w-full">

--- a/src/app/chat/container/SearchBar.tsx
+++ b/src/app/chat/container/SearchBar.tsx
@@ -1,11 +1,14 @@
 import { SearchIcon } from '@/shared/container/Icon/SearchIcon';
 import { Input } from 'antd';
-// import useGetChats from '../usecase/useGetChats';
 
-export default function SearchBar() {
+export default function SearchBar({
+  search,
+}: {
+  search: (keyword: string) => void;
+}) {
   return (
     <Input
-      // onChange={(e) => setKeyword(e.target.value)}
+      onChange={(e) => search(e.target.value)}
       name="search"
       prefix={<SearchIcon className="size-fit" />}
       className="flex h-[35px]"

--- a/src/app/chat/loading.tsx
+++ b/src/app/chat/loading.tsx
@@ -4,18 +4,19 @@ import PageTitle from '@/shared/container/PageTitle/PageTitle';
 
 export default function ChatsLoading() {
   return (
-    <>
+    <div className="grid grid-rows-[auto_1fr_auto] min-h-screen gap-y-2">
       <PageTitle withBackButton={false} title="Chats" />
-      <SkeletonInput className="p-4" active block />
-      <section className="p-4 flex flex-col gap-4">
-        {Array(10)
-          .fill(0)
-          .map((chat, index) => (
-            <SkeletonInput active block key={chat + index} />
-          ))}
-      </section>
-
+      <div className="px-4 flex flex-col gap-3">
+        <SkeletonInput active block />
+        <section className="flex flex-col gap-2">
+          {Array(10)
+            .fill(0)
+            .map((chat, index) => (
+              <SkeletonInput active block key={chat + index} />
+            ))}
+        </section>
+      </div>
       <BottomNav />
-    </>
+    </div>
   );
 }

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -8,26 +8,23 @@ import { BottomNav } from '@/shared/container/Navigation/BottomNav';
 import EmptySection from '@/shared/container/Section/EmptySection';
 
 export default function ChatsPage() {
-  const { listAllChat } = useGetChats();
+  const { listAllChat, searchChat } = useGetChats();
   return (
-    <>
+    <div className="grid grid-rows-[auto_1fr_auto] min-h-dvh gap-y-2">
       <PageTitle withBackButton={false} title="Chats" />
-
-      <div className="p-4">
-        <SearchBar />
+      <div className="px-4 flex flex-col gap-3 size-full">
+        <SearchBar search={searchChat} />
+        <section className="flex flex-col gap-2">
+          {listAllChat.render.length > 0 ? (
+            listAllChat.render.map((chat) => (
+              <ChatInfo chat={chat} key={chat.userInfo.uid} />
+            ))
+          ) : (
+            <EmptySection message="There are no messages" />
+          )}
+        </section>
       </div>
-
-      <section className="p-4 flex flex-col">
-        {listAllChat.render.length > 0 ? (
-          listAllChat.render.map((chat) => (
-            <ChatInfo chat={chat} key={chat.userInfo.uid} />
-          ))
-        ) : (
-          <EmptySection message="There are no messages" />
-        )}
-      </section>
-
       <BottomNav />
-    </>
+    </div>
   );
 }

--- a/src/app/chat/usecase/useMarkAsRead.ts
+++ b/src/app/chat/usecase/useMarkAsRead.ts
@@ -1,5 +1,5 @@
 import { TListChats } from '@/shared/models/chatInterfaces';
-import { doc, serverTimestamp, updateDoc } from 'firebase/firestore';
+import { doc, updateDoc } from 'firebase/firestore';
 import { db } from '../../../../firebase-config';
 import { getClientSession } from '@/shared/usecase/getClientSession';
 
@@ -15,7 +15,6 @@ const useMarkAsRead = (chat: TListChats) => {
         displayName: chat.userInfo.displayName,
         displayPicture: chat.userInfo.displayPicture,
       },
-      [combinedId + '.date']: serverTimestamp(),
       [combinedId + '.lastMessage']: {
         text: chat.lastMessage.text,
         isRead: true,

--- a/src/app/dashboard/container/Section/MyDashboardLoadingSection.tsx
+++ b/src/app/dashboard/container/Section/MyDashboardLoadingSection.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+
+export const MyDashboardLoadingSection = () => {
+  return (
+    <section className="grid grid-cols-2 gap-3 pt-3">
+      <div className="col-span-2 flex w-full h-[116px] animate-pulse bg-ny-gray-300 rounded-lg" />
+      <div className="flex w-full h-[116px] animate-pulse bg-ny-gray-300 rounded-lg" />
+      <div className="flex w-full h-[116px] animate-pulse bg-ny-gray-300 rounded-lg" />
+      <div className="row-span-2 flex w-full h-[244px] animate-pulse bg-ny-gray-300 rounded-lg" />
+      <div className="flex w-full h-[116px] animate-pulse bg-ny-gray-300 rounded-lg" />
+      <div className="flex w-full h-[116px] animate-pulse bg-ny-gray-300 rounded-lg" />
+    </section>
+  );
+};

--- a/src/app/dashboard/container/Section/MyDashboardSection.tsx
+++ b/src/app/dashboard/container/Section/MyDashboardSection.tsx
@@ -13,14 +13,12 @@ import React from 'react';
 import { useGetStatistics } from '../../usecase/useGetStatistics';
 import CustomErrorBoundary from '@/shared/container/ErrorBoundary/ErrorBoundary';
 import formatToRupiah from '@/shared/usecase/formatToRupiah';
+import { MyDashboardLoadingSection } from './MyDashboardLoadingSection';
 
 const MyDashboardSection = () => {
   const { data: result, isLoading, isError, error } = useGetStatistics();
 
-  if (isLoading)
-    return (
-      <div className="flex w-full h-[28rem] animate-pulse bg-ny-gray-300 rounded-lg mt-4" />
-    );
+  if (isLoading) return <MyDashboardLoadingSection />;
   if (isError) return <CustomErrorBoundary error={error} />;
   if (!result) return;
 

--- a/src/app/notification/container/MarkAllAsRead.tsx
+++ b/src/app/notification/container/MarkAllAsRead.tsx
@@ -3,9 +3,12 @@
 import { Button } from 'antd';
 import React from 'react';
 import { useReadAllNotifications } from '../usecase/useReadAllNotifications';
+import { useGetNotificationsCount } from '@/shared/usecase/useGetNotificationsCount';
 
 export const MarkAllAsRead = () => {
   const { mutate: readAll } = useReadAllNotifications();
+  const count = useGetNotificationsCount();
+  if (count === 0) return;
   return (
     <Button
       onClick={() => readAll()}

--- a/src/app/notification/page.tsx
+++ b/src/app/notification/page.tsx
@@ -2,7 +2,6 @@ import { getNotifications } from '@/shared/actions/notificationService';
 import React, { Suspense } from 'react';
 import { NotificationCard } from './container/NotificationCard';
 import { ReadNotifications } from './container/ReadNotifications';
-import NotificationLoading from './loading';
 
 const NotificationPage = async () => {
   const notifications = await getNotifications('unread');
@@ -25,7 +24,15 @@ const NotificationPage = async () => {
       ))}
 
       {/* Getting read notifications is expected to take longer than getting the unread ones, components is separated to reduce loading time */}
-      <Suspense fallback={<NotificationLoading />}>
+      <Suspense
+        fallback={
+          <div className="flex flex-col gap-3">
+            <div className="bg-ny-gray-100 rounded-lg h-24 animate-pulse" />
+            <div className="bg-ny-gray-100 rounded-lg h-24 animate-pulse" />
+            <div className="bg-ny-gray-100 rounded-lg h-24 animate-pulse" />
+            <div className="bg-ny-gray-100 rounded-lg h-24 animate-pulse" />
+          </div>
+        }>
         <ReadNotifications showDivider={hasNewNotifications} />
       </Suspense>
     </div>

--- a/src/app/todo/add/container/AddTodoContainer.tsx
+++ b/src/app/todo/add/container/AddTodoContainer.tsx
@@ -22,8 +22,8 @@ const AddTodoContainer = ({ categories }: { categories: string[] }) => {
     };
 
     try {
-      const ress = await addTodo(payload);
-      if (ress.success) {
+      const res = await addTodo(payload);
+      if (res.success) {
         message.success('Todo added successfully!');
         router.push('/todo');
       } else {
@@ -45,14 +45,12 @@ const AddTodoContainer = ({ categories }: { categories: string[] }) => {
         <div className="flex items-center gap-2">
           <Button
             className="flex items-center justify-center flex-1 rounded-[8px] h-[40px] bg-ny-primary-100 text-ny-primary-500 text-body-2"
-            onClick={() => form.resetFields()}
-          >
+            onClick={() => form.resetFields()}>
             Cancel
           </Button>
           <Button
             className="flex items-center justify-center flex-1 rounded-[8px] h-[40px] bg-ny-primary-500 text-white text-body-2"
-            onClick={() => form.submit()}
-          >
+            onClick={() => form.submit()}>
             Save
           </Button>
         </div>

--- a/src/app/todo/page.tsx
+++ b/src/app/todo/page.tsx
@@ -22,8 +22,11 @@ const Todo = async () => {
   if (typeof unresolvedData === 'string') throw Error(unresolvedData);
 
   return (
-    <main>
-      <TodoContainer data={data.data} unresolvedData={unresolvedData.data.todos} />
+    <main className="grid grid-rows-[1fr_auto] min-h-dvh">
+      <TodoContainer
+        data={data.data}
+        unresolvedData={unresolvedData.data.todos}
+      />
       <BottomNav />
     </main>
   );

--- a/src/shared/container/Navigation/BottomNav.tsx
+++ b/src/shared/container/Navigation/BottomNav.tsx
@@ -12,7 +12,7 @@ export const BottomNav = () => {
   const pathName = usePathname();
 
   return (
-    <nav className="fixed bottom-0 text-caption-3 font-medium text-ny-primary-200 w-full max-w-screen-md mx-auto md:hidden bg-white z-30 grid grid-cols-5 px-2 justify-between">
+    <nav className="sticky bottom-0 text-caption-3 font-medium text-ny-primary-200 w-full max-w-screen-md mx-auto md:hidden bg-white z-30 grid grid-cols-5 px-2 justify-between">
       <BottomNavItem
         href="/discover"
         label="Home"

--- a/src/shared/container/NotificationBadge/NotificationBadge.tsx
+++ b/src/shared/container/NotificationBadge/NotificationBadge.tsx
@@ -12,7 +12,5 @@ export const NotificationBadge = ({
 }) => {
   const mounted = useMounted();
   const notificationCount = useGetNotificationsCount();
-  if (!mounted) return <Badge count={0}>{children}</Badge>;
-
-  return <Badge count={notificationCount}>{children}</Badge>;
+  return <Badge count={mounted ? notificationCount : 0}>{children}</Badge>;
 };

--- a/src/shared/container/PageTitle/PageTitle.tsx
+++ b/src/shared/container/PageTitle/PageTitle.tsx
@@ -9,7 +9,7 @@ interface IPageTitle {
 
 const PageTitle = ({ title, children, withBackButton = true }: IPageTitle) => {
   return (
-    <div className="px-4 py-2 flex justify-between items-center w-full max-w-screen-md">
+    <div className="px-4 py-2 flex justify-between items-center w-full max-w-screen-md sticky top-0 z-10 bg-white">
       <div className="flex items-center gap-3 w-[65%]">
         {withBackButton && <BackButton />}
         <h1 className="text-body-1 font-semibold truncate">{title}</h1>


### PR DESCRIPTION
I tried to fix this double scrollbar appearing that I noticed when fixing chat's UI, I still can't solve it until now, will continue trying to fix it in the next pull request.

<img width="1440" alt="image" src="https://github.com/user-attachments/assets/a8073b99-afbe-43ce-b51e-852f607ce4ae">

# Changes
1. Made `BottomNav` and `PageTitle` to use sticky position instead of fixed. I also made changes in todo page to make sure the bottom navbar stayed at the bottom after the change.
2. Improved some of the loading states (chats and dashboard page)
3. Integrating search chat
4. Fixed a bug where the timestamp change when user clicked on a chat room
5. Hide mark all as read button when there's no new notification
6. Handled budget empty state

![image](https://github.com/user-attachments/assets/93af37ff-8510-4ae0-8540-68c5a472cb6c)
